### PR TITLE
updated titles for window tabs

### DIFF
--- a/createAcct.html
+++ b/createAcct.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Bar Finder | Sign Up</title>
-    <!-- <link rel="icon" href="assets/images/beer.png"> -->
     <link rel="icon" href="assets/images/cocktail.png">
     <!-- Link to Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Alegreya:400,700" rel="stylesheet">

--- a/favorites.html
+++ b/favorites.html
@@ -4,7 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Bar Finder | Favorites</title>
-    <!-- <link rel="icon" href="assets/images/beer.png"> -->
     <link rel="icon" href="assets/images/cocktail.png">
     <!-- Link to Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Alegreya:400,700" rel="stylesheet">

--- a/recipe.html
+++ b/recipe.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Bar Finder | Search</title>
+    <title>Bar Finder | Recipes</title>
     <link rel="icon" href="assets/images/cocktail.png">
     <!-- Link to Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Alegreya:400,700" rel="stylesheet">

--- a/search-results.html
+++ b/search-results.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
         <meta charset="UTF-8">
-        <title>Bar Finder | Search</title>
-        <!-- <link rel="icon" href="assets/images/beer.png"> -->
+        <title>Bar Finder | Search Results</title>
         <link rel="icon" href="assets/images/cocktail.png">
         <!-- Link to Google Fonts -->
         <link href="https://fonts.googleapis.com/css?family=Alegreya:400,700" rel="stylesheet">
@@ -69,9 +68,6 @@
                 </ul>
             </div>
         </nav>
-    
-    
-   
 
 <!-- Start Footer -->
 


### PR DESCRIPTION
I updated the tab titles for those that weren't changed: for example, on the "Favorites" page, the tab will now be: "Bar Finder | Favorites".